### PR TITLE
[WIP] Sahara proxy domain users

### DIFF
--- a/keystone/lib/puppet/provider/keystone_domain/openstack.rb
+++ b/keystone/lib/puppet/provider/keystone_domain/openstack.rb
@@ -1,0 +1,143 @@
+require 'puppet/provider/keystone'
+require 'puppet/util/inifile'
+
+Puppet::Type.type(:keystone_domain).provide(
+  :openstack,
+  :parent => Puppet::Provider::Keystone
+) do
+
+  desc 'Provider that manages keystone domains'
+
+  @credentials = Puppet::Provider::Openstack::CredentialsV3.new
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def create
+    properties = [resource[:name]]
+    if resource[:enabled] == :true
+      properties << '--enable'
+    elsif resource[:enabled] == :false
+      properties << '--disable'
+    end
+    if resource[:description]
+      properties << '--description'
+      properties << resource[:description]
+    end
+    @property_hash = self.class.request('domain', 'create', properties)
+    @property_hash[:is_default] = sym_to_bool(resource[:is_default])
+    @property_hash[:ensure] = :present
+    ensure_default_domain(true)
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def destroy
+    # have to disable first - Keystone does not allow you to delete an
+    # enabled domain
+    self.class.request('domain', 'set', [resource[:name], '--disable'])
+    self.class.request('domain', 'delete', resource[:name])
+    @property_hash[:ensure] == :absent
+    ensure_default_domain(false, true)
+    @property_hash.clear
+  end
+
+  def enabled=(value)
+    @property_flush[:enabled] = value
+  end
+
+  def enabled
+    bool_to_sym(@property_hash[:enabled])
+  end
+
+  def description=(value)
+    @property_flush[:description] = value
+  end
+
+  def description
+    @property_hash[:description]
+  end
+
+  def id
+    @property_hash[:id]
+  end
+
+  def is_default
+    bool_to_sym(@property_hash[:is_default])
+  end
+
+  def is_default=(value)
+    @property_flush[:is_default] = value
+  end
+
+  def ensure_default_domain(create, destroy=false, value=nil)
+    if !self.class.keystone_file
+      return
+    end
+    changed = false
+    curid = self.class.default_domain_id
+    newid = id
+    default = (is_default == :true)
+    if (default && create) || (!default && (value == :true))
+      # new default domain, or making existing domain the default domain
+      if curid != newid
+        self.class.keystone_file['identity']['default_domain_id'] = newid
+        changed = true
+      end
+    elsif (default && destroy) || (default && (value == :false))
+      # removing default domain, or making this domain not the default
+      if curid == newid
+        # can't delete from inifile, so just reset to default 'default'
+        self.class.keystone_file['identity']['default_domain_id'] = 'default'
+        changed = true
+        newid = 'default'
+      end
+    end
+    if changed
+      self.class.keystone_file.store
+      debug("The default_domain_id was changed from #{curid} to #{newid}")
+    end
+  end
+
+  def self.instances
+    request('domain', 'list').collect do |domain|
+      new(
+        :name        => domain[:name],
+        :ensure      => :present,
+        :enabled     => domain[:enabled].downcase.chomp == 'true' ? true : false,
+        :description => domain[:description],
+        :id          => domain[:id],
+        :is_default  => domain[:id] == default_domain_id
+      )
+    end
+  end
+
+  def self.prefetch(resources)
+    domains = instances
+    resources.keys.each do |name|
+      if provider = domains.find{ |domain| domain.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def flush
+    options = []
+    if @property_flush && !@property_flush.empty?
+      options << '--enable' if @property_flush[:enabled] == :true
+      options << '--disable' if @property_flush[:enabled] == :false
+      if @property_flush[:description]
+        options << '--description' << resource[:description]
+      end
+      self.class.request('domain', 'set', [resource[:name]] + options) unless options.empty?
+      if @property_flush[:is_default]
+        ensure_default_domain(false, false, @property_flush[:is_default])
+      end
+      @property_flush.clear
+    end
+  end
+end

--- a/keystone/lib/puppet/type/keystone_domain.rb
+++ b/keystone/lib/puppet/type/keystone_domain.rb
@@ -1,0 +1,54 @@
+# LP#1408531
+File.expand_path('../..', File.dirname(__FILE__)).tap { |dir| $LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir) }
+File.expand_path('../../../../openstacklib/lib', File.dirname(__FILE__)).tap { |dir| $LOAD_PATH.unshift(dir) unless $LOAD_PATH.include?(dir) }
+
+Puppet::Type.newtype(:keystone_domain) do
+
+  desc <<-EOT
+    This type can be used to manage
+    keystone domains.
+  EOT
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    newvalues(/\w+/)
+  end
+
+  newproperty(:enabled) do
+    newvalues(/(t|T)rue/, /(f|F)alse/, true, false )
+    defaultto(true)
+    munge do |value|
+      value.to_s.downcase.to_sym
+    end
+  end
+
+  newproperty(:description)
+
+  newproperty(:is_default) do
+    desc <<-EOT
+      If this is true, this is the default domain used for v2.0 requests when the domain
+      is not specified, or used by v3 providers if no other domain is specified.  The id
+      of this domain will be written to the keystone config identity/default_domain_id
+      value.
+    EOT
+    newvalues(/(t|T)rue/, /(f|F)alse/, true, false )
+    defaultto(false)
+    munge do |value|
+      value.to_s.downcase.to_sym
+    end
+  end
+
+  newproperty(:id) do
+    validate do |v|
+      raise(Puppet::Error, 'This is a read only property')
+    end
+  end
+
+  # we should not do anything until the keystone service is started
+  autorequire(:service) do
+    'keystone'
+  end
+
+
+end

--- a/keystone/spec/unit/provider/keystone_domain/openstack_spec.rb
+++ b/keystone/spec/unit/provider/keystone_domain/openstack_spec.rb
@@ -1,0 +1,192 @@
+require 'puppet'
+require 'spec_helper'
+require 'puppet/provider/keystone_domain/openstack'
+
+provider_class = Puppet::Type.type(:keystone_domain).provider(:openstack)
+
+class Puppet::Provider::Keystone
+  def self.reset
+    @admin_endpoint = nil
+    @tenant_hash    = nil
+    @admin_token    = nil
+    @keystone_file  = nil
+    @domain_id_to_name = nil
+    @default_domain_id = nil
+    @domain_hash = nil
+  end
+end
+
+describe provider_class do
+
+  after :each do
+    provider_class.reset
+  end
+
+  shared_examples 'authenticated with environment variables' do
+    ENV['OS_USERNAME']     = 'test'
+    ENV['OS_PASSWORD']     = 'abc123'
+    ENV['OS_PROJECT_NAME'] = 'test'
+    ENV['OS_AUTH_URL']     = 'http://127.0.0.1:35357/v2.0'
+  end
+
+  describe 'when managing a domain' do
+
+    let(:domain_attrs) do
+      {
+        :name         => 'foo',
+        :description  => 'foo',
+        :ensure       => 'present',
+        :enabled      => 'True',
+      }
+    end
+
+    let(:resource) do
+      Puppet::Type::Keystone_domain.new(domain_attrs)
+    end
+
+    let(:provider) do
+      provider_class.new(resource)
+    end
+
+    it_behaves_like 'authenticated with environment variables' do
+      describe '#create' do
+        it 'creates a domain' do
+          # keystone.conf
+          File.expects(:exists?).returns(true)
+          kcmock = {
+            'identity' => {'default_domain_id' => ' default'}
+          }
+          Puppet::Util::IniConfig::File.expects(:new).returns(kcmock)
+          kcmock.expects(:read).with('/etc/keystone/keystone.conf')
+          provider.class.expects(:openstack)
+                        .with('domain', 'create', '--format', 'shell', ['foo', '--enable', '--description', 'foo'])
+                        .returns('id="1cb05cfed7c24279be884ba4f6520262"
+name="foo"
+description="foo"
+enabled=True
+')
+          provider.create
+          expect(provider.exists?).to be_truthy
+        end
+
+      end
+
+      describe '#destroy' do
+        it 'destroys a domain' do
+          provider.instance_variable_get('@property_hash')[:id] = 'my-domainid'
+          # keystone.conf
+          File.expects(:exists?).returns(true)
+          kcmock = {
+            'identity' => {'default_domain_id' => ' default'}
+          }
+          Puppet::Util::IniConfig::File.expects(:new).returns(kcmock)
+          kcmock.expects(:read).with('/etc/keystone/keystone.conf')
+          provider.class.expects(:openstack)
+                        .with('domain', 'set', ['foo', '--disable'])
+          provider.class.expects(:openstack)
+                        .with('domain', 'delete', 'foo')
+          provider.destroy
+          expect(provider.exists?).to be_falsey
+        end
+
+      end
+
+      describe '#instances' do
+        it 'finds every domain' do
+          provider.class.expects(:openstack)
+                        .with('domain', 'list', '--quiet', '--format', 'csv', [])
+                        .returns('"ID","Name","Description","Enabled"
+"1cb05cfed7c24279be884ba4f6520262","foo","foo",True
+')
+          instances = provider_class.instances
+          expect(instances.count).to eq(1)
+        end
+      end
+
+      describe '#create default' do
+        let(:domain_attrs) do
+          {
+            :name         => 'foo',
+            :description  => 'foo',
+            :ensure       => 'present',
+            :enabled      => 'True',
+            :is_default   => 'True',
+          }
+        end
+
+        it 'creates a default domain' do
+          File.expects(:exists?).returns(true)
+          mock = {
+            'identity' => {'default_domain_id' => ' default'}
+          }
+          Puppet::Util::IniConfig::File.expects(:new).returns(mock)
+          mock.expects(:read).with('/etc/keystone/keystone.conf')
+          mock.expects(:store)
+          provider.class.expects(:openstack)
+                        .with('domain', 'create', '--format', 'shell', ['foo', '--enable', '--description', 'foo'])
+                        .returns('id="1cb05cfed7c24279be884ba4f6520262"
+name="foo"
+description="foo"
+enabled=True
+')
+          provider.create
+          expect(provider.exists?).to be_truthy
+          expect(mock['identity']['default_domain_id']).to eq('1cb05cfed7c24279be884ba4f6520262')
+        end
+      end
+
+      describe '#destroy default' do
+        it 'destroys a default domain' do
+          provider.instance_variable_get('@property_hash')[:is_default] = true
+          provider.instance_variable_get('@property_hash')[:id] = 'my-domainid'
+          # keystone.conf
+          File.expects(:exists?).returns(true)
+          kcmock = {
+            'identity' => {'default_domain_id' => ' my-domainid'}
+          }
+          Puppet::Util::IniConfig::File.expects(:new).returns(kcmock)
+          kcmock.expects(:read).with('/etc/keystone/keystone.conf')
+          kcmock.expects(:store)
+          provider.class.expects(:openstack)
+                        .with('domain', 'set', ['foo', '--disable'])
+          provider.class.expects(:openstack)
+                        .with('domain', 'delete', 'foo')
+          provider.destroy
+          expect(provider.exists?).to be_falsey
+          expect(kcmock['identity']['default_domain_id']).to eq('default')
+        end
+      end
+
+      describe '#flush' do
+        let(:domain_attrs) do
+          {
+            :name         => 'foo',
+            :description  => 'new description',
+            :ensure       => 'present',
+            :enabled      => 'True',
+            :is_default   => 'True',
+          }
+        end
+
+        it 'changes the description' do
+          provider.class.expects(:openstack)
+                        .with('domain', 'set', ['foo', '--description', 'new description'])
+          provider.description=('new description')
+          provider.flush
+        end
+
+        it 'changes is_default' do
+          # keystone.conf
+          File.expects(:exists?).returns(true)
+          kcmock = {
+            'identity' => {'default_domain_id' => ' my-domainid'}
+          }
+          Puppet::Util::IniConfig::File.expects(:new).returns(kcmock)
+          kcmock.expects(:read).with('/etc/keystone/keystone.conf')
+          provider.is_default=(true)
+          provider.flush
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sahara has a feature which uses Keystone trusts so temporary users can be created in a Keystone domain, for access to Swift. This will simplify some Cloud Dataverse UX stuff, as well as offer some security improvements.

- [x] Update Puppet manifests to allow creation of Keystone domain to contain the Sahara temp users  
- [ ] Test the temp user creation functionality locally  
- [ ] Puppetize necessary Sahara config which allows temp user creation  
- [ ] Cherry-pick the changes to Mitaka/Newton branch for Kaizen/Engage1 production use