### PR TITLE
Multi RBD backends

### DIFF
--- a/cinder/manifests/backend/rbd.pp
+++ b/cinder/manifests/backend/rbd.pp
@@ -74,14 +74,23 @@ define cinder::backend::rbd (
     "rbd/rbd_pool":                             value => $rbd_pool;
     "rbd/rbd_max_clone_depth":                  value => $rbd_max_clone_depth;
     "rbd/rbd_flatten_volume_from_snapshot":     value => $rbd_flatten_volume_from_snapshot;
+    "rbd/rbd_secret_uuid":                      value => $rbd_secret_uuid;
   }
 
-  if $rbd_secret_uuid {
-    cinder_config {"${name}/rbd_secret_uuid": ensure => absent;}
-    cinder_config {"rbd/rbd_secret_uuid":     value  => $rbd_secret_uuid;}
-  } else {
-    cinder_config {"${name}/rbd_secret_uuid": ensure => absent;}
+  if $::quickstack::params::cinder_perf_rbd_pool {
+  $name1 = $::quickstack::params::cinder_perf_rbd_pool
+  cinder_config {
+    "${name1}/volume_backend_name":                  value => $name1;
+    "${name1}/volume_driver":                        value => 'cinder.volume.drivers.rbd.RBDDriver';
+    "${name1}/rbd_ceph_conf":                        value => $rbd_ceph_conf;
+    "${name1}/rbd_user":                             value => $rbd_user;
+    "${name1}/rbd_pool":                             value => $name;
+    "${name1}/rbd_max_clone_depth":                  value => $rbd_max_clone_depth;
+    "${name1}/rbd_flatten_volume_from_snapshot":     value => $rbd_flatten_volume_from_snapshot;
+    "${name1}/rbd_secret_uuid":                      value => $rbd_secret_uuid;
+    }
   }
+
 
   if $volume_tmp_dir {
     cinder_config {"${name}/volume_tmp_dir": value => $volume_tmp_dir;}

--- a/cinder/manifests/backend/rbd.pp
+++ b/cinder/manifests/backend/rbd.pp
@@ -84,7 +84,7 @@ define cinder::backend::rbd (
     "${name1}/volume_driver":                        value => 'cinder.volume.drivers.rbd.RBDDriver';
     "${name1}/rbd_ceph_conf":                        value => $rbd_ceph_conf;
     "${name1}/rbd_user":                             value => $rbd_user;
-    "${name1}/rbd_pool":                             value => $name;
+    "${name1}/rbd_pool":                             value => $name1;
     "${name1}/rbd_max_clone_depth":                  value => $rbd_max_clone_depth;
     "${name1}/rbd_flatten_volume_from_snapshot":     value => $rbd_flatten_volume_from_snapshot;
     "${name1}/rbd_secret_uuid":                      value => $rbd_secret_uuid;

--- a/cinder/manifests/glance.pp
+++ b/cinder/manifests/glance.pp
@@ -73,7 +73,7 @@ class cinder::glance (
 #    }
 #  }
   if $::quickstack::params::cinder_perf_rbd_pool {
-    $backends = "$::quickstack::params::cinder_perf_rbd_pool, rbd"
+    $backends = "rbd, $::quickstack::params::cinder_perf_rbd_pool"
   }else
   {
     $backends = 'rbd'

--- a/cinder/manifests/glance.pp
+++ b/cinder/manifests/glance.pp
@@ -60,7 +60,7 @@ class cinder::glance (
   $glance_num_retries         = '0',
   $glance_api_insecure        = false,
   $glance_api_ssl_compression = false,
-  $glance_request_timeout     = undef
+  $glance_request_timeout     = undef,
 ) {
 
 #  if is_array($glance_api_servers) {
@@ -72,14 +72,19 @@ class cinder::glance (
 #      'DEFAULT/glance_api_servers': value => $glance_api_servers;
 #    }
 #  }
-
+  if $::quickstack::params::cinder_perf_rbd_pool {
+    $backends = "rbd, $::quickstack::params::cinder_perf_rbd_pool"
+  }else
+  {
+    $backends = 'rbd'
+  }
   cinder_config {
     'DEFAULT/glance_api_version':         value => $glance_api_version;
     'DEFAULT/glance_num_retries':         value => $glance_num_retries;
     'DEFAULT/glance_api_insecure':        value => $glance_api_insecure;
     'DEFAULT/glance_api_ssl_compression': value => $glance_api_ssl_compression;
     'DEFAULT/glance_request_timeout':     value => $glance_request_timeout;
-    'DEFAULT/enabled_backends':           value => 'rbd';
+    'DEFAULT/enabled_backends':           value => $backends;
   }
 
 }

--- a/cinder/manifests/glance.pp
+++ b/cinder/manifests/glance.pp
@@ -73,7 +73,7 @@ class cinder::glance (
 #    }
 #  }
   if $::quickstack::params::cinder_perf_rbd_pool {
-    $backends = "rbd, $::quickstack::params::cinder_perf_rbd_pool"
+    $backends = "$::quickstack::params::cinder_perf_rbd_pool, rbd"
   }else
   {
     $backends = 'rbd'

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -139,6 +139,7 @@ class quickstack::params (
   # $cinder_backend_netapp_name      = produce_array_with_prefix("netapp", 1, size($cinder_netapp_hostname)),
   #  Cinder RBD
   $cinder_rbd_pool,
+  $cinder_perf_rbd_pool = undef,
   $libvirt_rbd_pool,
   $cinder_rbd_ceph_conf,
   $cinder_rbd_flatten_volume_from_snapshot,


### PR DESCRIPTION
To enable the extra backend configure an optional parameter
quickstack::params::cinder_perf_rbd_pool
in hiera file.
If omitted there will be no extra backend configured.

Also on the command line - this is kzn specific:
cinder type-key Ceph set volume_backend_name=DEFAULT
openstack volume type create Ceph2
cinder type-key Ceph2 set volume_backend_name=performance-volumes
