### PR TITLE
Parameterize help URL

### DIFF
--- a/horizon/manifests/params.pp
+++ b/horizon/manifests/params.pp
@@ -5,7 +5,7 @@ class horizon::params {
   $logdir      = '/var/log/horizon'
   $django_wsgi = '/usr/share/openstack-dashboard/openstack_dashboard/wsgi/django.wsgi'
   $manage_py   = '/usr/share/openstack-dashboard/manage.py'
-
+  $help_url    = 'http://massopen.cloud/blog/wiki/kaizenfaqs'
   case $::osfamily {
     'RedHat': {
       $http_service                = 'httpd'


### PR DESCRIPTION
Help link URL can be specified in hiera file
horizon::help_url: 'http://custom.u.rl'

If omitted defaults to
http://massopen.cloud/blog/wiki/kaizenfaqs
