### PR TITLE
Switch Horizon to auth v3

### DIFF
--- a/horizon/templates/local_settings.py.erb
+++ b/horizon/templates/local_settings.py.erb
@@ -45,9 +45,9 @@ SESSION_COOKIE_SECURE = True
 # NOTE: The version should be formatted as it appears in the URL for the
 # service API. For example, The identity service APIs have inconsistent
 # use of the decimal point, so valid options would be "2.0" or "3".
-# OPENSTACK_API_VERSIONS = {
-#     "identity": 3
-# }
+OPENSTACK_API_VERSIONS = {
+ "identity": 3
+}
 
 # Set this to True if running on multi-domain model. When this is enabled, it
 # will require user to enter the Domain name in addition to username for login.
@@ -115,11 +115,11 @@ SECRET_KEY = '<%= @secret_key %>'
 #        'LOCATION' : '127.0.0.1:11211',
 #    }
 #}
+SESSION_ENGINE = 'django.contrib.sessions.backends.cache'
 
 CACHES = {
     'default': {
         <% if @cache_server_ip %>
-#        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache'
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
           <% if @cache_server_ip.kind_of?(Array) %>
             <%  split = ":" + @cache_server_port + "','" %>

--- a/keystone/manifests/endpoint.pp
+++ b/keystone/manifests/endpoint.pp
@@ -39,7 +39,7 @@ class keystone::endpoint (
 ) {
 
   $public_url_real = "${public_url}/${version}"
-  $admin_url_real = "${admin_url}/${version}"
+  $admin_url_real = "${admin_url}/v2.0"
 
   if $internal_url {
     $internal_url_real = "${internal_url}/${version}"

--- a/keystone/manifests/endpoint.pp
+++ b/keystone/manifests/endpoint.pp
@@ -34,7 +34,7 @@ class keystone::endpoint (
   $public_url        = 'http://127.0.0.1:5000',
   $internal_url      = undef,
   $admin_url         = 'http://127.0.0.1:35357',
-  $version           = 'v2.0',
+  $version           = '',
   $region            = 'RegionOne',
 ) {
 

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -741,7 +741,7 @@ class quickstack::controller_common (
     keystone_default_role => '_member_',
     #Keystone_host now keystone_url
     #keystone_host         => $controller_priv_host,
-    keystone_url          => "$keystone_pub_url/v2.0",
+    keystone_url          => "$keystone_pub_url/v3",
     fqdn                  => ["$controller_pub_host", "$::fqdn", "$::hostname", 'localhost', '*'],
     listen_ssl            => str2bool_i("$horizon_ssl"),
     horizon_cert          => $horizon_cert,

--- a/quickstack/manifests/horizon.pp
+++ b/quickstack/manifests/horizon.pp
@@ -71,7 +71,7 @@ class quickstack::horizon(
     cache_server_port     => $cache_server_port,
     fqdn                  => $fqdn,
     keystone_default_role => $keystone_default_role,
-    keystone_url          => "http://${keystone_host}:5000/v2.0",
+    keystone_url          => "http://${keystone_host}:5000/v3",
     horizon_cert          => $horizon_cert,
     horizon_key           => $horizon_key,
     horizon_ca            => $horizon_ca,


### PR DESCRIPTION
While still preserving v2 for legacy applications/configurations.