### PR TITLE
Sso

### DIFF
--- a/apache/manifests/init.pp
+++ b/apache/manifests/init.pp
@@ -73,6 +73,15 @@ class apache (
   $package_ensure         = 'installed',
   $use_optional_includes  = $::apache::params::use_optional_includes,
 ) inherits ::apache::params {
+  file { '/etc/httpd/conf.d/wsgi-keystone.conf':
+    ensure  => file,
+    path    => "${::apache::mod_dir}/wsgi-keystone.conf",
+    content => template('keystone/wsgi-keystone.erb'),
+    require => Exec["mkdir ${::apache::mod_dir}"],
+    before  => File[$::apache::mod_dir],
+    notify  => Class['apache::service'],
+  }
+
   validate_bool($default_vhost)
   validate_bool($default_ssl_vhost)
   validate_bool($default_confd_files)

--- a/apache/manifests/mod/ssl.pp
+++ b/apache/manifests/mod/ssl.pp
@@ -74,12 +74,12 @@ class apache::mod::ssl (
     notify  => Class['apache::service'],
   }
 
-  file { '/etc/httpd/conf.d/wsgi-keystone.conf':
-    ensure  => file,
-    path    => "${::apache::mod_dir}/wsgi-keystone.conf",
-    source => 'puppet:///modules/keystone/wsgi-keystone.conf',
-    require => Exec["mkdir ${::apache::mod_dir}"],
-    before  => File[$::apache::mod_dir],
-    notify  => Class['apache::service'],
-  }
+#  file { '/etc/httpd/conf.d/wsgi-keystone.conf':
+#    ensure  => file,
+#    path    => "${::apache::mod_dir}/wsgi-keystone.conf",
+#    content => template('keystone/wsgi-keystone.erb'),
+#    require => Exec["mkdir ${::apache::mod_dir}"],
+#    before  => File[$::apache::mod_dir],
+#    notify  => Class['apache::service'],
+#  }
 }

--- a/apache/manifests/package.pp
+++ b/apache/manifests/package.pp
@@ -62,9 +62,4 @@ class apache::package (
     name   => $apache_package,
     notify => Class['Apache::Service'],
   }
-
-  package { 'mod_auth_openidc':
-    ensure => $ensure,
-    notify => Class['Apache::Service'],
-  }
 }

--- a/apache/manifests/package.pp
+++ b/apache/manifests/package.pp
@@ -62,4 +62,9 @@ class apache::package (
     name   => $apache_package,
     notify => Class['Apache::Service'],
   }
+
+  package { 'mod_auth_openidc':
+    ensure => $ensure,
+    notify => Class['Apache::Service'],
+  }
 }

--- a/apache/manifests/params.pp
+++ b/apache/manifests/params.pp
@@ -24,7 +24,6 @@ class apache::params inherits ::apache::version {
   } else {
     $servername = $::hostname
   }
-
   # The default error log level
   $log_level = 'warn'
   $use_optional_includes = false
@@ -66,7 +65,7 @@ class apache::params inherits ::apache::version {
     $suphp_addhandler     = 'php5-script'
     $suphp_engine         = 'off'
     $suphp_configpath     = undef
-    # NOTE: The module for Shibboleth is not available to RH/CentOS without an additional repository. http://wiki.aaf.edu.au/tech-info/sp-install-guide
+          # NOTE: The module for Shibboleth is not available to RH/CentOS without an additional repository. http://wiki.aaf.edu.au/tech-info/sp-install-guide
     # NOTE: The auth_cas module isn't available to RH/CentOS without enabling EPEL.
     $mod_packages         = {
       'auth_cas'    => 'mod_auth_cas',

--- a/horizon/templates/local_settings.py.erb
+++ b/horizon/templates/local_settings.py.erb
@@ -590,3 +590,15 @@ HORIZON_IMAGES_UPLOAD_MODE = 'legacy'
 OPENSTACK_HEAT_STACK = {
     'enable_user_pass': False,
 }
+
+<% if scope.lookupvar('quickstack::params::sso_url') != :undef -%>
+WEBSSO_ENABLED = True
+WEBSSO_CHOICES = (
+    ("credentials", _("Local Openstack Account")),
+        ("moc_openid", _("Your Institution Account")),
+        )
+
+WEBSSO_IDP_MAPPING = {
+    "moc_openid": ("moc", "openid"),}
+<% end -%>
+

--- a/keystone/manifests/init.pp
+++ b/keystone/manifests/init.pp
@@ -519,6 +519,19 @@ class keystone(
       package_ensure => $client_package_ensure,
     }
   }
+  if $quickstack::params::sso_url {
+    keystone_config {
+      'auth/methods'                 : value => 'password,token,openid';
+      'openid/remote_id_attribute'   : value => 'HTTP_OIDC_ISS';
+      'federation/trusted_dashboard' : value => "$quickstack::params::controller_pub_url/dashboard/auth/websso/";
+    }
+  } else {
+    keystone_config {
+      'auth/methods'                 : ensure => absent;
+      'openid/remote_id_attribute'   : ensure => absent;
+      'federation/trusted_dashboard' : ensure => absent;
+    }
+  }
 
   group { 'keystone':
     ensure  => present,

--- a/keystone/templates/wsgi-keystone.erb
+++ b/keystone/templates/wsgi-keystone.erb
@@ -32,6 +32,38 @@ WSGIDaemonProcess keystone-admin processes=10 threads=1 user=keystone group=keys
             Allow from all
         </IfVersion>
     </Directory>
+    <% if scope.lookupvar('quickstack::params::sso_url') != :undef -%>
+
+    LoadModule auth_openidc_module modules/mod_auth_openidc.so
+    OIDCClaimPrefix "OIDC-"
+    OIDCResponseType "id_token"
+    OIDCScope "openid email profile"
+    OIDCProviderMetadataURL <%= scope.lookupvar('quickstack::params::sso_url') -%>auth/realms/moc/.well-known/openid-configuration
+    OIDCClientID <%= scope.lookupvar('quickstack::params::sso_uid') -%> 
+    OIDCClientSecret <%= scope.lookupvar('quickstack::params::sso_secret') -%> 
+    OIDCCryptoPassphrase openstack
+    OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/auth/OS-FEDERATION/identity_providers/moc/protocols/openid/websso
+    OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/auth/OS-FEDERATION/websso
+    OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/OS-FEDERATION/identity_providers/moc/protocols/openid/auth
+
+    OIDCOAuthClientID <%= scope.lookupvar('quickstack::params::sso_uid') -%> 
+    OIDCOAuthClientSecret <%= scope.lookupvar('quickstack::params::sso_secret') -%> 
+    OIDCOAuthIntrospectionEndpoint <%= scope.lookupvar('quickstack::params::sso_url') -%>auth/realms/moc/protocol/openid-connect/token/introspect
+    <LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
+        AuthType oauth20
+        Require valid-user
+    </LocationMatch>
+
+    <Location ~ "/v3/auth/OS-FEDERATION/websso">
+        AuthType openid-connect
+        Require valid-user
+    </Location>
+
+    <Location ~ "/v3/auth/OS-FEDERATION/identity_providers/moc/protocols/openid/websso">
+        AuthType openid-connect
+        Require valid-user
+    </Location>
+    <% end -%>
 </VirtualHost>
 
 <VirtualHost *:35357>

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -219,6 +219,9 @@ class quickstack::controller_common (
   $elasticsearch_host            = $quickstack::params::elasticsearch_host,
   $enable_ceilometer             = $quickstack::params::enable_ceilometer,
   $sahara_db_password            = $quickstack::params::sahara_db_password,
+  $sso_url                       = $quickstack::params::sso_url,
+  $sso_uid                       = $quickstack::params::sso_uid,
+  $sso_secret                    = $quickstack::params::sso_secret,
 ) inherits quickstack::params {
 
   if str2bool_i("$use_ssl_endpoints") {
@@ -839,6 +842,10 @@ class quickstack::controller_common (
   }
 
   package { "openstack-nova-placement-api":
+    ensure => latest,
+  }
+
+  package { "mod_auth_openidc":
     ensure => latest,
   }
 

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -450,5 +450,10 @@ class quickstack::params (
   $heat_domain_password,
   $sahara_plugins,
   $sahara_manage_policy,
+  
+  #SSO
+  $sso_url = undef,
+  $sso_uid = undef,
+  $sso_secret = undef,
 ) {
 }


### PR DESCRIPTION
SSO is enabled by setting hiera variables as below:
quickstack::params::sso_url: 'https://sso.massopen.cloud/'
quickstack::params::sso_uid: 'os-env'
quickstack::params::sso_secret: '******************'

Requires additional configuration on keycloak side and running once these commands

openstack domain create moc
openstack identity provider create --domain moc --remote-id https://sso.massopen.cloud/auth/realms/moc moc
echo '[
    {
        "local": [
            {
                "user": {
                    "name": "{0}"
                }
            }
        ],
        "remote": [
            {
                "type": "OIDC-preferred_username"
            }
        ]
    }
]' > ssomapping.json
openstack mapping create mapping_moc --rules ssomapping.json
openstack federation protocol create --identity-provider moc --mapping mapping_moc openid
