### PR TITLE
Fixes SSO redirect to websso instead of auth

### DIFF
--- a/keystone/templates/wsgi-keystone.erb
+++ b/keystone/templates/wsgi-keystone.erb
@@ -44,12 +44,15 @@ WSGIDaemonProcess keystone-admin processes=10 threads=1 user=keystone group=keys
     OIDCCryptoPassphrase openstack
     OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/auth/OS-FEDERATION/identity_providers/moc/protocols/openid/websso
     OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/auth/OS-FEDERATION/websso
-    OIDCRedirectURI <%= scope.lookupvar('quickstack::params::controller_pub_url') -%>:5000/v3/OS-FEDERATION/identity_providers/moc/protocols/openid/auth
+    
+    OIDCOAuthClientID <%= scope.lookupvar('quickstack::params::sso_uid') -%> 
+    OIDCOAuthClientSecret <%= scope.lookupvar('quickstack::params::sso_secret') -%> 
+    OIDCOAuthIntrospectionEndpoint <%= scope.lookupvar('quickstack::params::sso_url') -%>auth/realms/moc/protocol/openid-connect/token/introspect 
 
-    <LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
-        AuthType openid-connect
+    <Location ~ "/v3/OS-FEDERATION/identity_providers/moc/protocols/openid/auth">
+        AuthType oauth20
         Require valid-user
-    </LocationMatch>
+    </Location>
 
     <Location ~ "/v3/auth/OS-FEDERATION/websso">
         AuthType openid-connect
@@ -91,23 +94,6 @@ WSGIDaemonProcess keystone-admin processes=10 threads=1 user=keystone group=keys
             Allow from all
         </IfVersion>
     </Directory>
-
-    <% if scope.lookupvar('quickstack::params::sso_url') != :undef -%>
-    
-    OIDCOAuthClientID <%= scope.lookupvar('quickstack::params::sso_uid') -%>
-    
-    OIDCOAuthClientSecret <%= scope.lookupvar('quickstack::params::sso_secret') -%>
-    
-    OIDCOAuthIntrospectionEndpoint <%= scope.lookupvar('quickstack::params::sso_url') -%>auth/realms/moc/protocol/openid-connect/token/introspect
-    
-
-    OIDCClaimPrefix "OIDC-"
-
-    <LocationMatch /v3/OS-FEDERATION/identity_providers/.*?/protocols/openid/auth>
-        AuthType oauth20
-        Require valid-user
-    </LocationMatch>
-    <% end -%>
 </VirtualHost>
 
 Alias /identity /usr/bin/keystone-wsgi-public


### PR DESCRIPTION
The last `OIDCRedirectURI` was overwriting the correct value, causing it to be set as the redirect uri, and requiring as to have the `auth` path as `openid-connect`.