### PR TITLE
Sahara volumev2

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -58,6 +58,7 @@ class quickstack::sahara (
     'DEFAULT/proxy_command':              value => "\'ip netns exec qdhcp-{network_id} nc {host} {port}\'";
     'DEFAULT/use_rootwrap':               value => true;
     'DEFAULT/proxy_command_use_internal_ip': value => true;
+    'cinder/api_version': value => 2;
   }
   
   if str2bool_i($sahara_use_ssl) { 


### PR DESCRIPTION
We don't have a volumev3 endpoint in our catalog. Whether or not we actually need one is up to debate. For now, just make this change so that Sahara works with Cinder and doesn't error out.